### PR TITLE
fix: 月別収入カードの「今月」ボタンを常時表示に変更

### DIFF
--- a/src/features/dashboard/month-navigator.tsx
+++ b/src/features/dashboard/month-navigator.tsx
@@ -46,16 +46,15 @@ export function MonthNavigator({ year, month }: MonthNavigatorProps) {
             >
                 &gt;
             </Button>
-            {!isCurrentMonth && (
-                <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => router.push("/")}
-                    className="h-7 text-xs"
-                >
-                    今月
-                </Button>
-            )}
+            <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => router.push("/")}
+                className="h-7 text-xs"
+                disabled={isCurrentMonth}
+            >
+                今月
+            </Button>
         </div>
     );
 }


### PR DESCRIPTION
## 概要
- 「今月」ボタンを条件付き非表示から常時表示に変更
- 当月表示時は disabled にして操作不可とする

closes #2